### PR TITLE
Upgrade of Apache HTTP libraries version

### DIFF
--- a/examples/http-client-nio-demo/sbb/src/main/resources/META-INF/sbb-jar.xml
+++ b/examples/http-client-nio-demo/sbb/src/main/resources/META-INF/sbb-jar.xml
@@ -49,7 +49,7 @@
 					org.mobicents
 				</resource-adaptor-type-vendor>
 				<resource-adaptor-type-version>
-					1.0
+					2.0
 				</resource-adaptor-type-version>
 			</resource-adaptor-type-ref>
 			<activity-context-interface-factory-name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,22 +27,22 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpasyncclient</artifactId>
-				<version>4.0-beta3</version>
+				<version>4.1.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.2.1</version>
+				<version>4.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore</artifactId>
-				<version>4.2.2</version>
+				<version>4.4.5</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore-nio</artifactId>
-				<version>4.2.2</version>
+				<version>4.4.5</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-logging</groupId>

--- a/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra-type/Chapter-Resource_Adaptor_Type.xml
+++ b/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra-type/Chapter-Resource_Adaptor_Type.xml
@@ -11,7 +11,7 @@
 
 	<para>The Resource Adaptor Type is the interface which defines the contract between the RA implementations, the SLEE container, and the Applications running in it.</para>
 	
-	<para>The name of the RA Type is <literal>HttpClientNIO</literal>, its vendor is <literal>org.mobicents</literal> and its version is <literal>1.0</literal>.</para>
+	<para>The name of the RA Type is <literal>HttpClientNIO</literal>, its vendor is <literal>org.mobicents</literal> and its version is <literal>2.0</literal>.</para>
 
 	<xi:include
 		xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra-type/Section-Resource_Adaptor_Interface.xml
+++ b/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra-type/Section-Resource_Adaptor_Interface.xml
@@ -37,15 +37,6 @@ public interface HttpClientNIOResourceAdaptorSbbInterface {
 	<variablelist>
 		<varlistentry>
 			<term>
-				The	<literal>getHttpClientParams()</literal> method:
-			</term>
-			<listitem>
-				<para>Retrieves the params from the client managed by the RA.</para>
-			</listitem>
-		</varlistentry>
-
-		<varlistentry>
-			<term>
 				The <literal>execute(HttpUriRequest, HttpContext, Object)</literal>	method:
 			</term>
 			<listitem>

--- a/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Chapter-Resource_Adaptor.xml
+++ b/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Chapter-Resource_Adaptor.xml
@@ -11,7 +11,7 @@
 
 	<para>This chapter documents the &THIS.RA; Resource Adaptor Implementation details, such as the configuration properties, the default Resource Adaptor entities, and the JAIN SLEE 1.1 Tracers and Alarms used.</para>
 	
-	<para>The name of the RA is <literal>HttpClientNIO</literal>, its vendor is <literal>org.mobicents</literal> and its version is <literal>1.0</literal>.</para>
+	<para>The name of the RA is <literal>HttpClientNIO</literal>, its vendor is <literal>org.mobicents</literal> and its version is <literal>2.0</literal>.</para>
 	
 	<xi:include
 		xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Section-Configuration.xml
+++ b/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Section-Configuration.xml
@@ -31,7 +31,31 @@
           <entry>May be used to provide a class which is responsible for building the HTTP Client.</entry>
           <entry>java.lang.String</entry>
           <entry/>
-        </row>        
+        </row>
+        <row>
+          <entry>DEFAULT_MAX_CONNECTIONS_PER_ROUTE</entry>
+          <entry>Configures the client to override default limit of defaul max concurrent connections for routes.</entry>
+          <entry>java.lang.Integer</entry>
+          <entry>500</entry>
+        </row>
+        <row>
+          <entry>MAX_CONNECTIONS_TOTAL</entry>
+          <entry>Max total concurrent connections.</entry>
+          <entry>java.lang.Integer</entry>
+          <entry>1000</entry>
+        </row>
+        <row>
+          <entry>DEFAULT_SOCKET_TIMEOUT</entry>
+          <entry>Default socket timeout value for non-blocking I/O operations.</entry>
+          <entry>java.lang.Integer</entry>
+          <entry>30000</entry>
+        </row>
+        <row>
+          <entry>DEFAULT_CONNECT_TIMEOUT</entry>
+          <entry>Default connect timeout value for non-blocking connection requests.</entry>
+          <entry>java.lang.Integer</entry>
+          <entry>30000</entry>
+        </row>
       </tbody>
     </tgroup>
   </table>

--- a/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Section-Default_Resource_Adaptor_Entities.xml
+++ b/resources/http-client-nio/docs/sources/src/main/resources/en-US/ra/Section-Default_Resource_Adaptor_Entities.xml
@@ -23,7 +23,7 @@
 					org.mobicents
 				</resource-adaptor-type-vendor>
 				<resource-adaptor-type-version>
-					1.0
+					2.0
 				</resource-adaptor-type-version>
 			</resource-adaptor-type-ref>
 			<activity-context-interface-factory-name>

--- a/resources/http-client-nio/du/src/main/resources/META-INF/deploy-config.xml
+++ b/resources/http-client-nio/du/src/main/resources/META-INF/deploy-config.xml
@@ -6,6 +6,8 @@
 		<properties>
 			<property name="DEFAULT_MAX_CONNECTIONS_PER_ROUTE" type="java.lang.Integer" value="500" />
 			<property name="MAX_CONNECTIONS_TOTAL" type="java.lang.Integer" value="1000" />
+			<property name="DEFAULT_SOCKET_TIMEOUT" type="java.lang.Integer" value="30000" />
+			<property name="DEFAULT_CONNECT_TIMEOUT" type="java.lang.Integer" value="30000" />
 		</properties>
 		<ra-link name="HttpClientNIO" />
 	</ra-entity>

--- a/resources/http-client-nio/ra/src/main/java/org/mobicents/slee/ra/httpclient/nio/ra/HttpClientNIORequestActivityImpl.java
+++ b/resources/http-client-nio/ra/src/main/java/org/mobicents/slee/ra/httpclient/nio/ra/HttpClientNIORequestActivityImpl.java
@@ -68,12 +68,12 @@ public class HttpClientNIORequestActivityImpl implements HttpClientNIORequestAct
 	
 	void execute(HttpUriRequest request,
 			HttpContext context, Object applicationData) {		
-		future = ra.httpclient.execute(request, processHttpContext(context), getFutureCallback(applicationData));
+		future = ra.httpAsyncClient.execute(request, processHttpContext(context), getFutureCallback(applicationData));
 	}
 
 	void execute(HttpHost target, HttpRequest request,
 			HttpContext context, Object applicationData) {		
-		future = ra.httpclient.execute(target, request, processHttpContext(context), getFutureCallback(applicationData));
+		future = ra.httpAsyncClient.execute(target, request, processHttpContext(context), getFutureCallback(applicationData));
 	}
 	
 	private HttpContext processHttpContext(HttpContext context) {

--- a/resources/http-client-nio/ra/src/main/java/org/mobicents/slee/ra/httpclient/nio/ra/HttpClientNIOResourceAdaptorSbbInterfaceImpl.java
+++ b/resources/http-client-nio/ra/src/main/java/org/mobicents/slee/ra/httpclient/nio/ra/HttpClientNIOResourceAdaptorSbbInterfaceImpl.java
@@ -34,13 +34,6 @@ public class HttpClientNIOResourceAdaptorSbbInterfaceImpl implements
 				HttpClientNIOResourceAdaptorSbbInterfaceImpl.class.getName());
 	}
 
-	public HttpParams getHttpClientParams() {
-		if (!this.ra.isActive) {
-			throw new IllegalStateException("ra is not in active state");
-		}
-		return ra.httpclient.getParams();
-	}
-
 	public HttpClientNIORequestActivity execute(HttpHost target,
 			HttpRequest request, HttpContext context, Object applicationData)
 			throws SLEEException, StartActivityException {

--- a/resources/http-client-nio/ra/src/main/resources/META-INF/resource-adaptor-jar.xml
+++ b/resources/http-client-nio/ra/src/main/resources/META-INF/resource-adaptor-jar.xml
@@ -24,6 +24,7 @@
 			<config-property-type>java.lang.String</config-property-type>
 			<config-property-value></config-property-value>
 		</config-property>
+		<!-- Configuration entries used in case HTTP Client Factory is not utilized. -->
 		<config-property>
 			<description>Configures the client to override default limit of defaul max concurrent connections for routes</description>
 			<config-property-name>DEFAULT_MAX_CONNECTIONS_PER_ROUTE</config-property-name>
@@ -33,6 +34,16 @@
 			<description>Max total concurrent connections.</description>
 			<config-property-name>MAX_CONNECTIONS_TOTAL</config-property-name>
 			<config-property-type>java.lang.Integer</config-property-type>
-		</config-property>		
+		</config-property>
+		<config-property>
+			<description>Default socket timeout value for non-blocking I/O operations.</description>
+			<config-property-name>DEFAULT_SOCKET_TIMEOUT</config-property-name>
+			<config-property-type>java.lang.Integer</config-property-type>
+		</config-property>
+		<config-property>
+			<description>Default connect timeout value for non-blocking connection requests.</description>
+			<config-property-name>DEFAULT_CONNECT_TIMEOUT</config-property-name>
+			<config-property-type>java.lang.Integer</config-property-type>
+		</config-property>
 	</resource-adaptor>
 </resource-adaptor-jar>

--- a/resources/http-client-nio/ratype/src/main/java/org/mobicents/slee/ra/httpclient/nio/ratype/HttpClientNIOResourceAdaptorSbbInterface.java
+++ b/resources/http-client-nio/ratype/src/main/java/org/mobicents/slee/ra/httpclient/nio/ratype/HttpClientNIOResourceAdaptorSbbInterface.java
@@ -30,7 +30,6 @@ import javax.slee.resource.StartActivityException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 
 /**
@@ -40,13 +39,6 @@ import org.apache.http.protocol.HttpContext;
  * 
  */
 public interface HttpClientNIOResourceAdaptorSbbInterface {
-
-	/**
-	 * Retrieves the params from the client managed by the RA.
-	 * 
-	 * @return
-	 */
-	HttpParams getHttpClientParams();
 
 	/**
 	 * 

--- a/resources/http-servlet/ra/src/main/java/org/mobicents/slee/resource/http/HttpServletResourceAdaptor.java
+++ b/resources/http-servlet/ra/src/main/java/org/mobicents/slee/resource/http/HttpServletResourceAdaptor.java
@@ -460,8 +460,7 @@ public class HttpServletResourceAdaptor implements ResourceAdaptor, HttpServletR
         final Object lock = requestLock.getLock(requestEvent);
         synchronized (lock) {
             try {
-                sleeEndpoint.fireEvent(activity, eventType, requestEvent, null, null,
-                        EventFlags.REQUEST_EVENT_UNREFERENCED_CALLBACK);
+                sleeEndpoint.fireEvent(activity, eventType, requestEvent, null, null, EventFlags.REQUEST_EVENT_UNREFERENCED_CALLBACK);
                 // block thread until event has been processed
                 lock.wait(15000);
                 // the event was unreferenced or 15s timeout, if the activity is the request then end it


### PR DESCRIPTION
PR to introduces the following chanages for issue/10:
- version of HTTP libraries upgraded from "beta" to the most stable up2date
- backward compatibility of HTTP NIO RA broken (HttpClientNIOResourceAdaptorSbbInterface no longer exposes: HttpParams getHttpClientParams(); operation)
- version of RA bumped from 1.0 to 2.0

Impact on existing instllations:
- version of RA needs to be considered on deployment
- If HTTP_CLIENT_FACTORY used for RA, then new version of org.apache.http.nio.client.HttpAsyncClient should be considered