### PR TITLE
Build: 2.7.0 leftover fix

### DIFF
--- a/resources/http-servlet/war/pom.xml
+++ b/resources/http-servlet/war/pom.xml
@@ -33,7 +33,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <copy overwrite="true" verbose="true" file="target/${project.build.finalName}.war" toDir="${jboss.home}/server/${node}/deploy" />
+                                <copy overwrite="true" verbose="true" file="target/${project.build.finalName}.war" toDir="${jboss.home}/standalone/deployments" />
                             </tasks>
                         </configuration>
                     </execution>
@@ -45,7 +45,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <delete file="${jboss.home}/server/${node}/deploy/${project.build.finalName}.war" />
+                                <delete file="${jboss.home}/standalone/deployments/${project.build.finalName}.war" />
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Make sure the `war` ends up in the correct wildfly directory.

Executing goal `deploy-war` still had the archive ending up in a jboss5 directory (_server/default_)
This fixes it.

Please review and commit.